### PR TITLE
Feature: show slot number and slot offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ This command will generate results like below (depends on ERC20 you used):
 
 ```
 layout of @openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20:
-_balances [4771][mapping(address => uint256)]
-_allowances [4777][mapping(address => mapping(address => uint256))]
-_totalSupply [4779][uint256]
-_name [4781][string]
-_symbol [4783][string]
-_decimals [4785][uint8]
+_balances [0,0][mapping(address => uint256)]
+_allowances [1,0][mapping(address => mapping(address => uint256))]
+_totalSupply [2,0][uint256]
+_name [3,0][string]
+_symbol [4,0][string]
 ```
+
+In which "[3,0]" means slot 3 offset 0.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Or if you are using TypeScript, in your `hardhat.config.ts`:
 import "storagelens";
 ```
 
+You need to re-compile your contracts to generate storage layout information.
+
+```bash
+npx hardhat clean
+npx hardhat compile
+```
+
 ## Tasks
 
 This plugin creates task called 'printStorage'

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,14 @@ extendEnvironment((hre) => {
   hre.layoutLens = lazyObject(() => new LayoutLens(hre));
 });
 
+task(TASK_COMPILE).setAction(async function (args, hre, runSuper) {
+  for (const compiler of hre.config.solidity.compilers) {
+    compiler.settings.outputSelection["*"]["*"].push("storageLayout");
+  }
+  console.log('storagelen hooks compile task');
+  await runSuper(args);
+});
+
 task("printStorage", "Print storage for contract")
   .addFlag("noCompile", "Don't compile before running this task")
   .addPositionalParam("contractName", "The name of contract to print")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 const chalk = require("chalk");
 import { task, extendEnvironment } from "hardhat/config";
 import { lazyObject } from "hardhat/plugins";
-import { LayoutLens } from "./LayoutLens";
+import { LayoutLens, TypeReference } from "./LayoutLens";
 // This import is needed to let the TypeScript compiler know that it should include your type
 // extensions in your npm package's types file.
 import "./type-extensions";
@@ -39,16 +39,13 @@ task("printStorage", "Print storage for contract")
     printLayout(layout, 0);
   });
 
-function printLayout(layout: any, indent: number) {
+function printLayout(l: any, indent: number) {
+  const layout = l as TypeReference[]
   for (var i = 0; i < layout.length; i++) {
     const node = layout[i];
     const padding = " ".repeat(indent) + (indent == 0 ? "" : "- ");
-    console.log(
-      `${padding}${chalk.yellow(node.name)} [${node.id}][${chalk.magentaBright(
-        node.typeName
-      )}]`
-    );
-    if ("subType" in node) {
+    console.log(`${padding}${chalk.yellow(node.name)} [${node.slot},${node.offset}][${chalk.magentaBright(node.type)}]`);
+    if (node.subType.length > 0) {
       printLayout(node.subType, indent + 2);
     }
   }


### PR DESCRIPTION
The original version of storagelen displays each variable within a contract, this pull request further enriches this data by presenting the corresponding storage slot and offset for each variable.

The changes made include:
* Let solc generates storage layout.
* Parsing storage layout and find slot number recursivly.
* Example in README.

By having access to the specific slot and offset information, users of storagelen can gain a deeper understanding of the storage layout of their contracts, thereby assisting in debugging processes and further analysis.